### PR TITLE
Add AppSync URL and API key to Terraform outputs

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -9,3 +9,16 @@ output "lambda_bucket_name" {
 
   value = aws_s3_bucket.lambda_bucket.id
 }
+
+output "appsync_url" {
+  description = "AppSync GraphQL endpoint URL."
+
+  value = aws_appsync_graphql_api.appsync.uris["GRAPHQL"]
+}
+
+output "appsync_api_key" {
+  description = "AppSync API key (include as x-api-key header in requests)."
+
+  value     = aws_appsync_api_key.appsync_api_key.key
+  sensitive = true
+}


### PR DESCRIPTION
appsync_url  - the GraphQL endpoint to send requests to appsync_api_key - the key to pass as x-api-key header (marked sensitive)

https://claude.ai/code/session_015bkNV8TLLoLw5BWmbUXfjS